### PR TITLE
Add histogram datapoint translation to PRW receiver

### DIFF
--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -425,8 +425,48 @@ func addSummaryDatapoints(_ pmetric.SummaryDataPointSlice, _ labels.Labels, _ wr
 	// TODO: Implement this function
 }
 
-func addHistogramDatapoints(_ pmetric.HistogramDataPointSlice, _ labels.Labels, _ writev2.TimeSeries) {
-	// TODO: Implement this function
+func addHistogramDatapoints(dest pmetric.HistogramDataPointSlice, ls labels.Labels, ts writev2.TimeSeries) {
+	for _, hist := range ts.Histograms {
+		dp := dest.AppendEmpty()
+		dp.SetStartTimestamp(pcommon.Timestamp(ts.CreatedTimestamp * int64(time.Millisecond)))
+		dp.SetTimestamp(pcommon.Timestamp(hist.Timestamp * int64(time.Millisecond)))
+
+		switch c := hist.Count.(type) {
+		case *writev2.Histogram_CountInt:
+			dp.SetCount(c.CountInt)
+		case *writev2.Histogram_CountFloat:
+			dp.SetCount(uint64(c.CountFloat))
+		}
+
+		dp.SetSum(hist.Sum)
+
+		if hist.Schema == -53 {
+			for _, b := range hist.CustomValues {
+				dp.ExplicitBounds().Append(b)
+			}
+			if len(hist.PositiveCounts) > 0 {
+				for _, c := range hist.PositiveCounts {
+					dp.BucketCounts().Append(uint64(c))
+				}
+			} else if len(hist.PositiveDeltas) > 0 {
+				var acc int64
+				for _, d := range hist.PositiveDeltas {
+					acc += d
+					dp.BucketCounts().Append(uint64(acc))
+				}
+			}
+		}
+
+		attributes := dp.Attributes()
+		for _, l := range ls {
+			if l.Name == "instance" || l.Name == "job" ||
+				l.Name == labels.MetricName ||
+				l.Name == "otel_scope_name" || l.Name == "otel_scope_version" {
+				continue
+			}
+			attributes.PutStr(l.Name, l.Value)
+		}
+	}
 }
 
 // extractScopeInfo extracts the scope name and version from the labels. If the labels do not contain the scope name/version,

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"strings"
 	"sync"
@@ -16,6 +17,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	lru "github.com/hashicorp/golang-lru/v2"
 	promconfig "github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	writev2 "github.com/prometheus/prometheus/prompb/io/prometheus/write/v2"
 	promremote "github.com/prometheus/prometheus/storage/remote"
@@ -431,15 +433,17 @@ func addHistogramDatapoints(dest pmetric.HistogramDataPointSlice, ls labels.Labe
 		dp.SetStartTimestamp(pcommon.Timestamp(ts.CreatedTimestamp * int64(time.Millisecond)))
 		dp.SetTimestamp(pcommon.Timestamp(hist.Timestamp * int64(time.Millisecond)))
 
+		var count uint64
 		switch c := hist.Count.(type) {
 		case *writev2.Histogram_CountInt:
-			dp.SetCount(c.CountInt)
+			count = c.CountInt
 		case *writev2.Histogram_CountFloat:
-			dp.SetCount(uint64(c.CountFloat))
+			count = uint64(c.CountFloat)
 		}
-
+		dp.SetCount(count)
 		dp.SetSum(hist.Sum)
 
+		// Handle custom buckets schema.
 		if hist.Schema == -53 {
 			for _, b := range hist.CustomValues {
 				dp.ExplicitBounds().Append(b)
@@ -454,6 +458,25 @@ func addHistogramDatapoints(dest pmetric.HistogramDataPointSlice, ls labels.Labe
 					acc += d
 					dp.BucketCounts().Append(uint64(acc))
 				}
+			}
+		} else {
+			// Translate exponential buckets using the Prometheus histogram utilities.
+			var h *histogram.FloatHistogram
+			if hist.IsFloatHistogram() {
+				h = hist.ToFloatHistogram()
+			} else {
+				h = hist.ToIntHistogram().ToFloat(nil)
+			}
+
+			var prev float64
+			for it := h.AllBucketIterator(); it.Next(); {
+				b := it.At()
+				delta := b.Count - prev
+				prev = b.Count
+				if !math.IsInf(b.Upper, 1) {
+					dp.ExplicitBounds().Append(b.Upper)
+				}
+				dp.BucketCounts().Append(uint64(delta))
 			}
 		}
 

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -14,9 +14,12 @@ import (
 	"testing"
 	"time"
 
+	"math"
+
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	promconfig "github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/histogram"
 	writev2 "github.com/prometheus/prometheus/prompb/io/prometheus/write/v2"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/stretchr/testify/assert"
@@ -543,6 +546,81 @@ func TestTranslateV2(t *testing.T) {
 				dp.ExplicitBounds().FromRaw([]float64{1, 2})
 				dp.BucketCounts().FromRaw([]uint64{1, 2, 3})
 				dp.Attributes().PutStr("foo", "bar")
+
+				return metrics
+			}(),
+			expectedStats: remote.WriteResponseStats{},
+		},
+		{
+			name: "exponential histogram",
+			request: func() *writev2.Request {
+				h := histogram.Histogram{
+					Schema:          2,
+					ZeroThreshold:   1e-128,
+					Count:           3,
+					Sum:             20,
+					PositiveSpans:   []histogram.Span{{Offset: 0, Length: 1}},
+					PositiveBuckets: []int64{1},
+					NegativeSpans:   []histogram.Span{{Offset: 0, Length: 1}},
+					NegativeBuckets: []int64{2},
+				}
+				return &writev2.Request{
+					Symbols: []string{"", "__name__", "hist_metric", "job", "service/test", "instance", "host1"},
+					Timeseries: []writev2.TimeSeries{
+						{
+							Metadata:         writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+							LabelsRefs:       []uint32{1, 2, 3, 4, 5, 6},
+							Histograms:       []writev2.Histogram{writev2.FromIntHistogram(1, &h)},
+							CreatedTimestamp: 1,
+						},
+					},
+				}
+			}(),
+			expectedMetrics: func() pmetric.Metrics {
+				h := histogram.Histogram{
+					Schema:          2,
+					ZeroThreshold:   1e-128,
+					Count:           3,
+					Sum:             20,
+					PositiveSpans:   []histogram.Span{{Offset: 0, Length: 1}},
+					PositiveBuckets: []int64{1},
+					NegativeSpans:   []histogram.Span{{Offset: 0, Length: 1}},
+					NegativeBuckets: []int64{2},
+				}
+				fh := h.ToFloat(nil)
+				bounds := make([]float64, 0)
+				counts := make([]uint64, 0)
+				var prev float64
+				for it := fh.AllBucketIterator(); it.Next(); {
+					b := it.At()
+					delta := b.Count - prev
+					prev = b.Count
+					if !math.IsInf(b.Upper, 1) {
+						bounds = append(bounds, b.Upper)
+					}
+					counts = append(counts, uint64(delta))
+				}
+
+				metrics := pmetric.NewMetrics()
+				rm := metrics.ResourceMetrics().AppendEmpty()
+				attrs := rm.Resource().Attributes()
+				attrs.PutStr("service.namespace", "service")
+				attrs.PutStr("service.name", "test")
+				attrs.PutStr("service.instance.id", "host1")
+
+				sm := rm.ScopeMetrics().AppendEmpty()
+				sm.Scope().SetName("OpenTelemetry Collector")
+				sm.Scope().SetVersion("latest")
+
+				m := sm.Metrics().AppendEmpty()
+				m.SetName("hist_metric")
+				dp := m.SetEmptyHistogram().DataPoints().AppendEmpty()
+				dp.SetStartTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				dp.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				dp.SetCount(uint64(fh.Count))
+				dp.SetSum(fh.Sum)
+				dp.ExplicitBounds().FromRaw(bounds)
+				dp.BucketCounts().FromRaw(counts)
 
 				return metrics
 			}(),

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -489,6 +489,65 @@ func TestTranslateV2(t *testing.T) {
 				return metrics
 			}(),
 		},
+		{
+			name: "custom histogram",
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__", "hist_metric", // 1, 2
+					"job", "service/test", // 3,4
+					"instance", "host1", //5,6
+					"foo", "bar", //7,8
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8},
+						Histograms: []writev2.Histogram{
+							{
+								Count:          &writev2.Histogram_CountInt{CountInt: 6},
+								Sum:            6,
+								Schema:         -53,
+								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 3}},
+								PositiveCounts: []float64{1, 2, 3},
+								Timestamp:      1,
+								CustomValues:   []float64{1, 2},
+							},
+						},
+						CreatedTimestamp: 1,
+					},
+				},
+			},
+			expectedMetrics: func() pmetric.Metrics {
+				metrics := pmetric.NewMetrics()
+				rm := metrics.ResourceMetrics().AppendEmpty()
+				attrs := rm.Resource().Attributes()
+				attrs.PutStr("service.namespace", "service")
+				attrs.PutStr("service.name", "test")
+				attrs.PutStr("service.instance.id", "host1")
+
+				sm := rm.ScopeMetrics().AppendEmpty()
+				sm.Scope().SetName("OpenTelemetry Collector")
+				sm.Scope().SetVersion("latest")
+
+				m := sm.Metrics().AppendEmpty()
+				m.SetName("hist_metric")
+				m.SetUnit("")
+				m.SetDescription("")
+
+				dp := m.SetEmptyHistogram().DataPoints().AppendEmpty()
+				dp.SetStartTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				dp.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				dp.SetCount(6)
+				dp.SetSum(6)
+				dp.ExplicitBounds().FromRaw([]float64{1, 2})
+				dp.BucketCounts().FromRaw([]uint64{1, 2, 3})
+				dp.Attributes().PutStr("foo", "bar")
+
+				return metrics
+			}(),
+			expectedStats: remote.WriteResponseStats{},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// since we are using the rmCache to store values across requests, we need to clear it after each test, otherwise it will affect the next test


### PR DESCRIPTION
## Summary
- implement addHistogramDatapoints for the PRW receiver
- test histogram translation using custom buckets

## Testing
- `go test -run TestTranslateV2 -count=1 ./receiver/prometheusremotewritereceiver`

------
https://chatgpt.com/codex/tasks/task_e_6840a1fbb968832185e21541709cf84f